### PR TITLE
Specified build_tools_version in WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -67,6 +67,7 @@ load("@build_bazel_rules_android//android:rules.bzl", "android_sdk_repository")
 android_sdk_repository(
     name = "androidsdk",
     api_level = 29,
+    build_tools_version = "29.0.3",
 )
 
 ## Kotlin


### PR DESCRIPTION
Currently, the latest version of build tools is "31.0.0-rc4" 
By default bazel picked it up as the latest on my machine and I've got the following build error:

```console
ERROR: /private/var/tmp/_bazel_morfly/6bc862c50a54fc9c63b307deff3fdde5/external/maven/BUILD:59:11: Dexing external/maven/_dx/androidx_annotation_annotation_experimental/classes_and_libs_merged.jar_desugared.jar with applicable dexopts [] failed: (Exit 1): d8_dexbuilder failed: error executing command bazel-out/darwin-opt-exec-2B5CBBC6/bin/external/bazel_tools/tools/android/d8_dexbuilder ... (remaining 1 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
Error: Could not find or load main class com.android.tools.r8.compatdexbuilder.CompatDexBuilder
Caused by: java.lang.ClassNotFoundException: com.android.tools.r8.compatdexbuilder.CompatDexBuilder
Target //compose-app:compose_example_app failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.882s, Critical Path: 0.65s
INFO: 9 processes: 9 internal.
FAILED: Build did NOT complete successfully
```

With explicitly specified  29.0.3 version the project builds successfully