### PR TITLE
Updated compose to stable 1.0.0 version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.iml
 /.aswb
 /.ijwb
+/.idea
 /bazel-*

--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,11 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "define_kt_toolchain", "kt_compiler_plugin", "kt_javac_options", "kt_kotlinc_options")
+load(
+    "@io_bazel_rules_kotlin//kotlin:kotlin.bzl",
+    "define_kt_toolchain",
+    "kt_compiler_plugin",
+    "kt_javac_options",
+    "kt_jvm_import",
+    "kt_kotlinc_options",
+)
 load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain")
 
 # Java Toolchain
@@ -38,5 +45,18 @@ kt_compiler_plugin(
     visibility = ["//visibility:public"],
     deps = [
         "@maven//:androidx_compose_compiler_compiler",
+    ],
+)
+
+# Add missing 'sun.misc' files to coroutines artifact
+# Used in 'override_targets' by referencing @//:kotlinx_coroutines_core_jvm
+kt_jvm_import(
+    name = "kotlinx_coroutines_core_jvm",
+    jars = ["@maven_secondary//:v1/https/repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.5.1/kotlinx-coroutines-core-jvm-1.5.1.jar"],
+    srcjar = "@maven_secondary//:v1/https/repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.5.1/kotlinx-coroutines-core-jvm-1.5.1-sources.jar",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//stub:sun_misc",
+        "@maven//:org_jetbrains_kotlin_kotlin_stdlib",
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,6 +4,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 _KOTLIN_COMPILER_VERSION = "1.5.10"
 
+_COMPOSE_VERSION = "1.0.0"
+
 ## JVM External
 
 _RULES_JVM_EXTERNAL_VERSION = "4.1"
@@ -24,25 +26,35 @@ load("@rules_jvm_external//:defs.bzl", "maven_install")
 maven_install(
     artifacts = [
         "org.jetbrains.kotlin:kotlin-stdlib:{}".format(_KOTLIN_COMPILER_VERSION),
-        "androidx.core:core-ktx:1.3.2",
-        "androidx.appcompat:appcompat:1.2.0",
-        "com.google.android.material:material:1.2.1",
-        "androidx.activity:activity-compose:1.3.0-alpha02",
-        "androidx.compose.material:material:1.0.0-beta08",
-        "androidx.compose.ui:ui:1.0.0-beta08",
-        "androidx.compose.ui:ui-tooling:1.0.0-beta08",
-        "androidx.compose.compiler:compiler:1.0.0-beta08",
-        "androidx.compose.runtime:runtime:1.0.0-beta08",
+        "androidx.core:core-ktx:1.6.0",
+        "androidx.appcompat:appcompat:1.3.1",
+        "com.google.android.material:material:1.4.0",
+        "androidx.activity:activity-compose:1.3.0",
+        "androidx.compose.material:material:{}".format(_COMPOSE_VERSION),
+        "androidx.compose.ui:ui:{}".format(_COMPOSE_VERSION),
+        "androidx.compose.ui:ui-tooling:{}".format(_COMPOSE_VERSION),
+        "androidx.compose.compiler:compiler:{}".format(_COMPOSE_VERSION),
+        "androidx.compose.runtime:runtime:{}".format(_COMPOSE_VERSION),
     ],
     override_targets = {
-        "org.jetbrains.kotlin:kotlin-stdlib": "@com_github_jetbrains_kotlin//:kotlin-stdlib",
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk7": "@com_github_jetbrains_kotlin//:kotlin-stdlib-jdk7",
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": "@com_github_jetbrains_kotlin//:kotlin-stdlib-jdk8",
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": "@//:kotlinx_coroutines_core_jvm",
     },
     repositories = [
         "https://maven.google.com",
         "https://repo1.maven.org/maven2",
     ],
+)
+
+# Secondary maven repository used mainly for workarounds
+maven_install(
+    name = "maven_secondary",
+    artifacts = [
+        # Workaround to add missing 'sun.misc' dependencies to 'kotlinx-coroutines-core-jvm' artifact
+        # Check root BUILD file and 'override_targets' arg of a primary 'maven_install'
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.5.1",
+    ],
+    fetch_sources = True,
+    repositories = ["https://repo1.maven.org/maven2"],
 )
 
 ## Android

--- a/compose-ui/AndroidManifest.xml
+++ b/compose-ui/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="cm.ben.android.bazel.compose.example.ui">
 
     <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="29" />
@@ -15,5 +16,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- Resolve a conflict issue while building with Bazel. -->
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            tools:node="remove" />
     </application>
 </manifest>

--- a/stub/BUILD
+++ b/stub/BUILD
@@ -1,0 +1,11 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+java_library(
+    name = "sun_misc",
+    srcs = [
+        "sun/misc/Signal.java",
+        "sun/misc/SignalHandler.java",
+    ],
+    neverlink = True,
+    visibility = ["//visibility:public"],
+)

--- a/stub/sun/misc/Signal.java
+++ b/stub/sun/misc/Signal.java
@@ -1,0 +1,4 @@
+package sun.misc;
+
+public final class Signal {
+}

--- a/stub/sun/misc/SignalHandler.java
+++ b/stub/sun/misc/SignalHandler.java
@@ -1,0 +1,4 @@
+package sun.misc;
+
+public interface SignalHandler {
+}


### PR DESCRIPTION
Updated compose to stable 1.0.0 version.

Added workaround for 'kotlinx-coroutines-core-jvm' artifact with adding missing 'sun.misc' classes.
(as per this solution: [bazel_issue_13553](https://github.com/Bencodes/bazel_issue_13553/blob/bazel-issue-13553-desugar-workaround/WORKSPACE))
