### PR TITLE
Add RBE cross compile repro

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -11,3 +11,24 @@ build:ci \
     --experimental_persistent_javac \
     --persistent_android_resource_processor \
     --disk_cache=~/.cache/bazel/
+
+build --define=EXECUTOR=remote
+build --disk_cache=
+build --experimental_inmemory_dotd_files
+build --experimental_inmemory_jdeps_files
+build --incompatible_strict_action_env=true
+build --remote_timeout=600
+build --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+build --crosstool_top=@remote_config//cc:toolchain
+build --extra_execution_platforms=@remote_config//config:platform
+build --extra_toolchains=@remote_config//config:cc-toolchain
+build --host_platform=@remote_config//config:platform
+build --platforms=@remote_config//config:platform
+build --jobs=150
+
+build --remote_executor=grpcs://remotebuildexecution.googleapis.com
+build --google_default_credentials
+build --noremote_local_fallback
+build --remote_instance_name=SOME_INSTANCE_NAME
+build --cpu=k8
+build --host_cpu=k8

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -69,10 +69,15 @@ http_archive(
     ],
 )
 
-load("@build_bazel_rules_android//android:rules.bzl", "android_sdk_repository")
+load("@build_bazel_rules_android//android:rules.bzl", "android_ndk_repository", "android_sdk_repository")
 
 android_sdk_repository(
     name = "androidsdk",
+    api_level = 30,
+)
+
+android_ndk_repository(
+    name = "androidndk",
     api_level = 30,
 )
 
@@ -99,3 +104,15 @@ kotlin_repositories(
 )
 
 register_toolchains("//:kotlin_toolchain")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "remote_config",
+    # Change the sha256 digest to the value of the `configs_tarball_digest` in the manifest you
+    # got when you ran the curl command above.
+    sha256 = "9f81180099ebc84da906c53cf56c1e9835d7dbc4bbc8ac5c7e075f050c450c3a",
+    urls = [
+        "https://storage.googleapis.com/rbe-toolchain/bazel-configs/bazel_5.0.0/rbe-ubuntu1604/latest/rbe_default.tar",
+    ],
+)


### PR DESCRIPTION
When building to RBE from a macOS host this fails with this error:

```
Output:
bazel-out/k8-opt-exec-BB7A5810/bin/external/androidsdk/aapt2_binary: line 7: /b/f/w/bazel-out/k8-opt-exec-BB7A5810/bin/external/androidsdk/aapt2_binary.runfiles/androidsdk/build-tools/30.0.2/aapt2: cannot execute binary file: Exec format error
bazel-out/k8-opt-exec-BB7A5810/bin/external/androidsdk/aapt2_binary: line 7: /b/f/w/bazel-out/k8-opt-exec-BB7A5810/bin/external/androidsdk/aapt2_binary.runfiles/androidsdk/build-tools/30.0.2/aapt2: Success

                at com.google.devtools.build.android.CommandHelper.execute(CommandHelper.java:42)
                at com.google.devtools.build.android.AaptCommandBuilder.execute(AaptCommandBuilder.java:297)
                at com.google.devtools.build.android.aapt2.ResourceCompiler$CompileTask.compile(ResourceCompiler.java:234)
                at com.google.devtools.build.android.aapt2.ResourceCompiler$CompileTask.call(ResourceCompiler.java:166)
                at com.google.devtools.build.android.aapt2.ResourceCompiler$CompileTask.call(ResourceCompiler.java:125)
                at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:125)
                at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:69)
                at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:78)
                at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
                at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
                at java.base/java.lang.Thread.run(Thread.java:829)
Target //compose-app:compose_example_app failed to build
Use --verbose_failures to see the command lines of failed build steps.
```

It appears to be uploading a macho binary and trying to execute that on
a linux executor

Repro on a mac with:

```
bazelisk build //compose-app:compose_example_app --remote_instance_name=SOME_INSTANCE_NAME
```