### PR TITLE
Update Kotlin and Compose

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -22,12 +22,12 @@ kt_javac_options(
 
 define_kt_toolchain(
     name = "kotlin_toolchain",
-    api_version = "1.5",
+    api_version = "1.6",
     experimental_use_abi_jars = True,
     javac_options = "//:kt_javac_options",
     jvm_target = "1.8",
     kotlinc_options = "//:kt_kotlinc_options",
-    language_version = "1.5",
+    language_version = "1.6",
 )
 
 # Define the compose compiler plugin
@@ -47,8 +47,8 @@ kt_compiler_plugin(
 # Used in 'override_targets' by referencing @//:kotlinx_coroutines_core_jvm
 kt_jvm_import(
     name = "kotlinx_coroutines_core_jvm",
-    jars = ["@maven_secondary//:v1/https/repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.5.1/kotlinx-coroutines-core-jvm-1.5.1.jar"],
-    srcjar = "@maven_secondary//:v1/https/repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.5.1/kotlinx-coroutines-core-jvm-1.5.1-sources.jar",
+    jars = ["@maven_secondary//:v1/https/repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.1/kotlinx-coroutines-core-jvm-1.6.1.jar"],
+    srcjar = "@maven_secondary//:v1/https/repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.1/kotlinx-coroutines-core-jvm-1.6.1-sources.jar",
     visibility = ["//visibility:public"],
     deps = [
         "//stub:sun_misc",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,7 +2,11 @@ workspace(name = "bazel_jetpack_compose_example")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-_KOTLIN_COMPILER_VERSION = "1.5.21"
+_COMPOSE_VERSION = "1.2.0-beta02"
+
+_KOTLIN_COMPILER_VERSION = "1.6.21"
+
+_KOTLIN_COMPILER_SHA = "632166fed89f3f430482f5aa07f2e20b923b72ef688c8f5a7df3aa1502c6d8ba"
 
 ## JVM External
 
@@ -24,14 +28,14 @@ load("@rules_jvm_external//:defs.bzl", "maven_install")
 maven_install(
     artifacts = [
         "org.jetbrains.kotlin:kotlin-stdlib:{}".format(_KOTLIN_COMPILER_VERSION),
-        "androidx.core:core-ktx:1.6.0",
-        "androidx.appcompat:appcompat:1.3.0",
-        "androidx.activity:activity-compose:1.3.0",
-        "androidx.compose.material:material:1.0.2",
-        "androidx.compose.ui:ui:1.0.2",
-        "androidx.compose.ui:ui-tooling:1.0.2",
-        "androidx.compose.compiler:compiler:1.0.2",
-        "androidx.compose.runtime:runtime:1.0.2",
+        "androidx.core:core-ktx:1.7.0",
+        "androidx.appcompat:appcompat:1.4.1",
+        "androidx.activity:activity-compose:1.4.0",
+        "androidx.compose.material:material:{}".format(_COMPOSE_VERSION),
+        "androidx.compose.ui:ui:{}".format(_COMPOSE_VERSION),
+        "androidx.compose.ui:ui-tooling:{}".format(_COMPOSE_VERSION),
+        "androidx.compose.compiler:compiler:{}".format(_COMPOSE_VERSION),
+        "androidx.compose.runtime:runtime:{}".format(_COMPOSE_VERSION),
     ],
     override_targets = {
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": "@//:kotlinx_coroutines_core_jvm",
@@ -40,6 +44,7 @@ maven_install(
         "https://maven.google.com",
         "https://repo1.maven.org/maven2",
     ],
+    version_conflict_policy = "pinned",
 )
 
 # Secondary maven repository used mainly for workarounds
@@ -48,7 +53,7 @@ maven_install(
     artifacts = [
         # Workaround to add missing 'sun.misc' dependencies to 'kotlinx-coroutines-core-jvm' artifact
         # Check root BUILD file and 'override_targets' arg of a primary 'maven_install'
-        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.5.1",
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.1",
     ],
     fetch_sources = True,
     repositories = ["https://repo1.maven.org/maven2"],
@@ -73,19 +78,19 @@ load("@build_bazel_rules_android//android:rules.bzl", "android_sdk_repository")
 
 android_sdk_repository(
     name = "androidsdk",
-    api_level = 30,
+    api_level = 31,
 )
 
 ## Kotlin
 
 # Enable Kotlin
-_RULES_KOTLIN_VERSION = "v1.5.0-beta-4"
+_RULES_KOTLIN_VERSION = "1.6.0"
 
 http_archive(
     name = "io_bazel_rules_kotlin",
-    sha256 = "6cbd4e5768bdfae1598662e40272729ec9ece8b7bded8f0d2c81c8ff96dc139d",
+    sha256 = "a57591404423a52bd6b18ebba7979e8cd2243534736c5c94d35c89718ea38f94",
     urls = [
-        "https://github.com/bazelbuild/rules_kotlin/releases/download/{}/rules_kotlin_release.tgz".format(_RULES_KOTLIN_VERSION),
+        "https://github.com/bazelbuild/rules_kotlin/releases/download/v{}/rules_kotlin_release.tgz".format(_RULES_KOTLIN_VERSION),
     ],
 )
 
@@ -94,7 +99,7 @@ load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories", "
 kotlin_repositories(
     compiler_release = kotlinc_version(
         release = _KOTLIN_COMPILER_VERSION,
-        sha256 = "f3313afdd6abf1b8c75c6292f4e41f2dbafefc8f6c72762c7ba9b3daeef5da59",
+        sha256 = _KOTLIN_COMPILER_SHA,
     ),
 )
 


### PR DESCRIPTION
Updating rules_kotlin to the latest stable version, Kotlin compiler to 1.6.x, and compose to the latest compatible beta.